### PR TITLE
Update the list of persisent folders in VDIGuide.md

### DIFF
--- a/tutorials/VDIGuide.md
+++ b/tutorials/VDIGuide.md
@@ -37,12 +37,8 @@ As we said before, we asked IT to set up special folders. The full list of the f
 ```
 /home/$USER/Android
 /home/$USER/AndroidStudioProjects
-/home/$USER/.config
 /home/$USER/.java
-/home/$USER/.cache
-/home/$USER/.gradle
 /home/$USER/.android
-/home/$USER/.bashrc
 ```
 
 Folders that start with ```.``` will store the temporary results of building your app. However, to achieve persistence, reading and writing these folders are slow. So, if you find that building, indexing, and downloading in these folders are slow, that’s the normal case.


### PR DESCRIPTION
Reported by IT: https://support.epfl.ch/epfl?id=epfl_ticket&table=incident&sys_id=3611071ac3da2650122bbe4c05013165

> - Having .cache and .config directory on a remote NAS comes with a lot of issues. Please check last year incident.
> - Having .bashrc on a NAS make the login to the VM impossible on any small error inside the file. The student are then unable to login to the VDI.
